### PR TITLE
Nested folders fix

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -54,7 +54,7 @@
   warn = baseTitle(yellow, "!");
   ensureDir = function(dir){
     if (!fs.existsSync(dir)) {
-      return fs.mkdirSync(dir);
+      return fs.mkdirSync(dir, { recursive: true});
     }
   };
   ensureDir(compileddir);

--- a/compile.js
+++ b/compile.js
@@ -54,7 +54,7 @@
   warn = baseTitle(yellow, "!");
   ensureDir = function(dir){
     if (!fs.existsSync(dir)) {
-      return fs.mkdirSync(dir, { recursive: true});
+      return fs.mkdirSync(dir, { recursive: true });
     }
   };
   ensureDir(compileddir);


### PR DESCRIPTION
When compiling with nested folders, "ENOENT, no such file or directory" error occurs. I added recursive option to fs.mkdirSync(dir) call, and now it works like a charm. 